### PR TITLE
api: clean public surface — single radius source, AnimatedEdgeFadeView, hide raw native

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ import { EdgeFadeView } from 'react-native-edge-fade';
 | `curve`  | `EdgeFadeCurve`                       | `'smooth'` | Default curve shape for all active edges             |
 | `mode`   | `'mask' \| 'overlay'`                 | auto       | Render mode; inferred from `color` when omitted      |
 | `color`  | `ColorValue`                          | —          | Global overlay color (implies `mode="overlay"`)      |
-| `radius` | `number`                              | —          | Corner radius, applied as a native clip path         |
+| `radius` | `number`                              | —          | Corner radius (dp). Use this instead of `style.borderRadius` |
 | `style`  | `ViewStyle`                           | —          | Forwarded to the native view                         |
 
 ### Edge prop forms

--- a/README.md
+++ b/README.md
@@ -299,28 +299,24 @@ compressed screenshots.
 
 ---
 
-## Scroll-driven fades
+## Animated fades (Reanimated)
 
-For static fades, use `EdgeFadeView`. For UI-thread scroll animation with
-Reanimated, wrap the raw Fabric component, then animate the native `fadeTop`,
-`fadeBottom`, `fadeLeft`, or `fadeRight` props directly.
+For UI-thread animated fades, use `AnimatedEdgeFadeView`. It accepts the same
+ergonomic props as `EdgeFadeView` and additionally a `SharedValue<number>` on
+any size-like prop (`top`, `bottom`, `left`, `right`, `start`, `end`, `radius`).
 
-The package intentionally does not export a pre-wrapped `AnimatedEdgeFadeView`:
-that would either add a Reanimated dependency or encourage animating `top` /
-`bottom`, which collide with Yoga layout props.
+Updates driven by a `SharedValue` stay on the UI thread — no bridge, no React
+re-render. Static props (`mode`, `curve`, `color`, …) work as usual.
 
 ```tsx
 import Animated, {
   Extrapolation,
   interpolate,
-  useAnimatedProps,
   useAnimatedScrollHandler,
+  useDerivedValue,
   useSharedValue,
 } from 'react-native-reanimated';
-import { NativeEdgeFadeView } from 'react-native-edge-fade';
-
-const ReanimatedNativeEdgeFadeView =
-  Animated.createAnimatedComponent(NativeEdgeFadeView);
+import { AnimatedEdgeFadeView } from 'react-native-edge-fade';
 
 function FeedScreen() {
   const scrollY = useSharedValue(0);
@@ -329,36 +325,37 @@ function FeedScreen() {
     scrollY.value = event.contentOffset.y;
   });
 
-  const animatedProps = useAnimatedProps(() => {
-    return {
-      fadeTop: interpolate(
-        scrollY.value,
-        [0, 80],
-        [0, 60],
-        Extrapolation.CLAMP
-      ),
-      fadeBottom: 80,
-      mode: 'mask',
-    };
-  });
+  // SharedValue derived from scroll position — fade depth grows as you scroll.
+  const topFade = useDerivedValue(() =>
+    interpolate(scrollY.value, [0, 80], [0, 60], Extrapolation.CLAMP)
+  );
 
   return (
-    <ReanimatedNativeEdgeFadeView
-      animatedProps={animatedProps}
-      style={{ flex: 1 }}
-    >
+    <AnimatedEdgeFadeView top={topFade} bottom={80} style={{ flex: 1 }}>
       <Animated.ScrollView scrollEventThrottle={16} onScroll={onScroll}>
         {/* content */}
       </Animated.ScrollView>
-    </ReanimatedNativeEdgeFadeView>
+    </AnimatedEdgeFadeView>
   );
 }
 ```
 
-> **Note** — animate the flat native props (`fadeTop`, `fadeBottom`,
-> `fadeLeft`, `fadeRight`) rather than the ergonomic JS props (`top`, `bottom`,
-> `left`, `right`). The JS props are normalized by `EdgeFadeView`; Reanimated
-> animated props mutate the native view directly.
+> Reanimated is an **optional** peer dependency. Install
+> `react-native-reanimated` and follow its Babel setup to use
+> `AnimatedEdgeFadeView`. If Reanimated is missing the component throws a
+> clear error on first render; the static `EdgeFadeView` works without it.
+
+### Power-user escape hatch
+
+The raw Fabric component is available via a dedicated subpath for cases that
+need full control over the flat native props (`fadeTop`, `fadeBottom`, …,
+`fadeRadius`):
+
+```tsx
+import { NativeEdgeFadeView } from 'react-native-edge-fade/native';
+```
+
+Most apps never need this — prefer `AnimatedEdgeFadeView`.
 
 ---
 
@@ -369,6 +366,7 @@ All types are exported from the package root:
 ```ts
 import type {
   EdgeFadeViewProps,
+  AnimatedEdgeFadeViewProps,
   EdgeFadeCurve,
   EdgeFadeMode,
   EdgeConfig,

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,6 @@
     "build:ios": "xcodebuild ONLY_ACTIVE_ARCH=YES -workspace ios/EdgeFadeExample.xcworkspace -UseNewBuildSystem=YES -scheme EdgeFadeExample -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet",
     "build:android": "cd android && ./gradlew assembleDebug -DtestBuildType=debug -Dorg.gradle.jvmargs=-Xmx4g",
     "build:web": "expo export --platform web"
-    
   },
   "dependencies": {
     "@expo/metro-runtime": "~55.0.11",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,26 +13,16 @@ import type { ImageSourcePropType } from 'react-native';
 import Animated, {
   Extrapolation,
   interpolate,
-  useAnimatedProps,
   useAnimatedScrollHandler,
+  useDerivedValue,
   useSharedValue,
 } from 'react-native-reanimated';
-import { EdgeFadeView, NativeEdgeFadeView } from 'react-native-edge-fade';
+import { EdgeFadeView, AnimatedEdgeFadeView } from 'react-native-edge-fade';
 import BenchmarkScreen from './BenchmarkScreen';
 
-// ── Reanimated native EdgeFadeView ────────────────────────────────────────────
-//
-// We wrap NativeEdgeFadeView (the raw Fabric component), NOT the JS EdgeFadeView
-// wrapper.  Reason: Reanimated's useAnimatedProps fires a UI-thread worklet that
-// mutates the shadow node directly.  If we animate `top` on the JS wrapper, the
-// mutation lands on Yoga's `top` layout property (shifting the view down).
-// Animating `fadeTop` on the native component targets the registered @ReactProp
-// instead — no layout side-effects.
-//
-// Created at module level so Reanimated never re-registers the component.
-
-const ReanimatedNativeEdgeFadeView =
-  Animated.createAnimatedComponent(NativeEdgeFadeView);
+// AnimatedEdgeFadeView accepts a SharedValue on size-like props (top, bottom,
+// left, right, start, end, radius) and routes them through a Reanimated
+// useAnimatedProps worklet so updates stay on the UI thread.
 
 // ── Palette ───────────────────────────────────────────────────────────────────
 
@@ -408,13 +398,11 @@ function DemoScreen({ onBenchmark }: { onBenchmark: () => void }) {
   // ── Scroll-driven top fade via Reanimated SharedValue ──────────────────────
   //
   // scrollY lives entirely on the UI thread — no JS-thread bridge round-trip.
+  // topFade is a derived SharedValue that grows the top fade as the user
+  // scrolls down, and is fed directly to AnimatedEdgeFadeView's `top` prop.
   //
-  // topFadeProps animates `fadeTop` (native prop) directly on NativeEdgeFadeView
-  // via Reanimated's UI-thread shadow-node mutation.  Using `fadeTop` avoids the
-  // Yoga layout collision that would occur if we animated the JS wrapper's `top`.
-  //
-  //   scrollY = 0  → fadeTop = 0   (at the very top, no top fade needed)
-  //   scrollY = 80 → fadeTop = 60  (full 60 dp top fade — content above)
+  //   scrollY = 0   → topFade = 0    (at the very top, no top fade needed)
+  //   scrollY = 120 → topFade = 120  (full 120 dp top fade — content above)
 
   const scrollY = useSharedValue(0);
 
@@ -422,14 +410,9 @@ function DemoScreen({ onBenchmark }: { onBenchmark: () => void }) {
     scrollY.set(event.contentOffset.y);
   });
 
-  const topFadeProps = useAnimatedProps(() => ({
-    fadeTop: interpolate(
-      scrollY.value,
-      [0, 120],
-      [0, 120],
-      Extrapolation.CLAMP
-    ),
-  }));
+  const topFade = useDerivedValue(() =>
+    interpolate(scrollY.value, [0, 120], [0, 120], Extrapolation.CLAMP)
+  );
 
   const filtered =
     activeCategory === 'All'
@@ -486,19 +469,15 @@ function DemoScreen({ onBenchmark }: { onBenchmark: () => void }) {
       {/*
        * Masonry grid — mask mode, scroll-driven top fade via Reanimated.
        *
-       * ReanimatedNativeEdgeFadeView wraps NativeEdgeFadeView directly so Reanimated's
-       * UI-thread worklet can mutate `fadeTop` as a @ReactProp without
-       * colliding with Yoga layout.
-       *
-       * Static props (fadeBottom, mode, curve*) are passed as normal React props.
-       * The animated prop (fadeTop) is driven by the scroll SharedValue.
+       * `top` is a SharedValue<number> — AnimatedEdgeFadeView routes it
+       * through a UI-thread worklet so the fade depth updates without a JS
+       * round-trip. `bottom` stays a static EdgeConfig with its own curve.
        */}
-      <ReanimatedNativeEdgeFadeView
-        animatedProps={topFadeProps}
-        fadeBottom={600}
+      <AnimatedEdgeFadeView
+        top={topFade}
+        bottom={{ size: 600, curve: 'smooth' }}
         mode="mask"
-        curveTop="gentle"
-        curveBottom="smooth"
+        curve="gentle"
         style={s.gridWrap}
       >
         <Animated.ScrollView
@@ -520,7 +499,7 @@ function DemoScreen({ onBenchmark }: { onBenchmark: () => void }) {
             </View>
           </View>
         </Animated.ScrollView>
-      </ReanimatedNativeEdgeFadeView>
+      </AnimatedEdgeFadeView>
     </View>
   );
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,13 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-reanimated": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-reanimated": {
+      "optional": true
+    }
   },
   "workspaces": [
     "example"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
       "types": "./lib/typescript/src/index.d.ts",
       "default": "./lib/module/index.js"
     },
+    "./native": {
+      "source": "./src/native.ts",
+      "types": "./lib/typescript/src/native.d.ts",
+      "default": "./lib/module/native.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/src/AnimatedEdgeFadeView.native.tsx
+++ b/src/AnimatedEdgeFadeView.native.tsx
@@ -1,0 +1,186 @@
+import { memo, type ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
+
+import NativeEdgeFadeView from './EdgeFadeViewNativeComponent';
+import { resolveNativeProps, resolveRadius } from './normalize';
+import type { EdgeConfig, EdgeFadeViewProps } from './types';
+
+// ── SharedValue typing (structural) ────────────────────────────────────────────
+// We avoid a hard type-import from `react-native-reanimated` so the package
+// keeps it as a soft peer dependency. The structural shape below matches any
+// Reanimated SharedValue<T> (and any user-defined object with the same surface).
+
+type SharedValueLike<T> = {
+  readonly value: T;
+  readonly addListener: (
+    listenerID: number,
+    listener: (newValue: T) => void
+  ) => void;
+};
+
+type EdgeProp =
+  | boolean
+  | number
+  | EdgeConfig
+  | SharedValueLike<number>
+  | undefined;
+
+export interface AnimatedEdgeFadeViewProps extends Omit<
+  EdgeFadeViewProps,
+  'top' | 'bottom' | 'left' | 'right' | 'start' | 'end' | 'radius'
+> {
+  top?: EdgeProp;
+  bottom?: EdgeProp;
+  left?: EdgeProp;
+  right?: EdgeProp;
+  start?: EdgeProp;
+  end?: EdgeProp;
+  radius?: number | SharedValueLike<number>;
+}
+
+// ── Reanimated soft peer dependency ────────────────────────────────────────────
+
+let Reanimated: any = null;
+
+let AnimatedNativeEdgeFadeView: any = null;
+
+try {
+  Reanimated = require('react-native-reanimated');
+  AnimatedNativeEdgeFadeView =
+    Reanimated.default.createAnimatedComponent(NativeEdgeFadeView);
+} catch {
+  // Reanimated not installed — component throws on render with a clear message.
+}
+
+function isSharedValue(x: unknown): x is SharedValueLike<unknown> {
+  if (Reanimated?.isSharedValue) {
+    return Reanimated.isSharedValue(x);
+  }
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    'value' in x &&
+    typeof (x as any).addListener === 'function'
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export const AnimatedEdgeFadeView = memo(function AnimatedEdgeFadeView(
+  props: AnimatedEdgeFadeViewProps
+): ReactElement {
+  if (!Reanimated || !AnimatedNativeEdgeFadeView) {
+    throw new Error(
+      '[AnimatedEdgeFadeView] `react-native-reanimated` is not installed. ' +
+        'Install it (and follow its Babel setup) to use this component, or ' +
+        'use the static `EdgeFadeView` instead.'
+    );
+  }
+
+  const { useAnimatedProps } = Reanimated;
+
+  // Identify SharedValue inputs on the animatable surface (sizes + radius).
+  // Capturing the references at render time is required so the worklet can
+  // read `.value` on the UI thread.
+  const topSV = isSharedValue(props.top)
+    ? (props.top as SharedValueLike<number>)
+    : null;
+  const bottomSV = isSharedValue(props.bottom)
+    ? (props.bottom as SharedValueLike<number>)
+    : null;
+  const leftSV = isSharedValue(props.left)
+    ? (props.left as SharedValueLike<number>)
+    : null;
+  const rightSV = isSharedValue(props.right)
+    ? (props.right as SharedValueLike<number>)
+    : null;
+  const startSV = isSharedValue(props.start)
+    ? (props.start as SharedValueLike<number>)
+    : null;
+  const endSV = isSharedValue(props.end)
+    ? (props.end as SharedValueLike<number>)
+    : null;
+  const radiusSV = isSharedValue(props.radius)
+    ? (props.radius as SharedValueLike<number>)
+    : null;
+
+  // Build the static prop set: replace any SharedValue with 0 so
+  // resolveNativeProps emits an inactive edge, then let animatedProps
+  // override the size on the UI thread.
+  const staticProps: EdgeFadeViewProps = {
+    ...(props as EdgeFadeViewProps),
+    top: topSV ? 0 : (props.top as EdgeFadeViewProps['top']),
+    bottom: bottomSV ? 0 : (props.bottom as EdgeFadeViewProps['bottom']),
+    left: leftSV ? 0 : (props.left as EdgeFadeViewProps['left']),
+    right: rightSV ? 0 : (props.right as EdgeFadeViewProps['right']),
+    start: startSV ? 0 : (props.start as EdgeFadeViewProps['start']),
+    end: endSV ? 0 : (props.end as EdgeFadeViewProps['end']),
+    radius: radiusSV ? undefined : (props.radius as number | undefined),
+  };
+
+  const n = resolveNativeProps(staticProps);
+  const resolvedRadius = resolveRadius(staticProps.radius, props.style);
+
+  const {
+    top: _t,
+    bottom: _b,
+    left: _l,
+    right: _r,
+    start: _st,
+    end: _en,
+    size: _s,
+    curve: _c,
+    mode: _m,
+    color: _col,
+    radius: _radius,
+    style,
+    children,
+    ...viewProps
+  } = props as AnimatedEdgeFadeViewProps & { children?: React.ReactNode };
+
+  const flat = (StyleSheet.flatten(style) ?? {}) as Record<string, unknown>;
+  const { borderRadius: _ignoredBorderRadius, ...cleanStyle } = flat;
+
+  // Resolve which logical SharedValue maps to which physical native prop, mirroring
+  // the LTR/RTL mapping that resolveNativeProps applies for non-animated edges.
+  // We assume LTR at the JS thread level (default); for RTL the user should pass
+  // `start` instead of `left` etc. — same convention as the static API.
+  const animatedProps = useAnimatedProps(() => {
+    'worklet';
+
+    const out: any = {};
+    if (topSV) out.fadeTop = topSV.value;
+    if (bottomSV) out.fadeBottom = bottomSV.value;
+    if (leftSV) out.fadeLeft = leftSV.value;
+    if (rightSV) out.fadeRight = rightSV.value;
+    if (startSV) out.fadeLeft = startSV.value; // LTR mapping (matches static API default)
+    if (endSV) out.fadeRight = endSV.value;
+    if (radiusSV) out.fadeRadius = radiusSV.value;
+    return out;
+  });
+
+  return (
+    <AnimatedNativeEdgeFadeView
+      {...viewProps}
+      style={cleanStyle}
+      fadeTop={n.fadeTop}
+      fadeBottom={n.fadeBottom}
+      fadeLeft={n.fadeLeft}
+      fadeRight={n.fadeRight}
+      curveTop={n.curveTop}
+      curveBottom={n.curveBottom}
+      curveLeft={n.curveLeft}
+      curveRight={n.curveRight}
+      mode={n.mode}
+      overlayColor={n.overlayColor}
+      overlayColorTop={n.overlayColorTop}
+      overlayColorBottom={n.overlayColorBottom}
+      overlayColorLeft={n.overlayColorLeft}
+      overlayColorRight={n.overlayColorRight}
+      fadeRadius={resolvedRadius}
+      animatedProps={animatedProps}
+    >
+      {children}
+    </AnimatedNativeEdgeFadeView>
+  );
+});

--- a/src/AnimatedEdgeFadeView.tsx
+++ b/src/AnimatedEdgeFadeView.tsx
@@ -1,0 +1,74 @@
+import { memo, type ReactElement } from 'react';
+
+import { EdgeFadeView } from './EdgeFadeView';
+import type { EdgeConfig, EdgeFadeViewProps } from './types';
+
+// Web has no equivalent to Reanimated's UI-thread updates, so we only support
+// reading SharedValue-like objects once at render time. The component renders
+// through the regular EdgeFadeView with the unwrapped values.
+
+type SharedValueLike<T> = {
+  readonly value: T;
+  readonly addListener: (
+    listenerID: number,
+    listener: (newValue: T) => void
+  ) => void;
+};
+
+type EdgeProp =
+  | boolean
+  | number
+  | EdgeConfig
+  | SharedValueLike<number>
+  | undefined;
+
+export interface AnimatedEdgeFadeViewProps extends Omit<
+  EdgeFadeViewProps,
+  'top' | 'bottom' | 'left' | 'right' | 'start' | 'end' | 'radius'
+> {
+  top?: EdgeProp;
+  bottom?: EdgeProp;
+  left?: EdgeProp;
+  right?: EdgeProp;
+  start?: EdgeProp;
+  end?: EdgeProp;
+  radius?: number | SharedValueLike<number>;
+}
+
+function isSharedValueLike(x: unknown): x is SharedValueLike<unknown> {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    'value' in x &&
+    typeof (x as any).addListener === 'function'
+  );
+}
+
+function unwrap<T>(v: T | SharedValueLike<T> | undefined): T | undefined {
+  if (v == null) return undefined;
+  if (isSharedValueLike(v)) return v.value as T;
+  return v as T;
+}
+
+function unwrapEdge(prop: EdgeProp): EdgeFadeViewProps['top'] {
+  if (prop == null) return undefined;
+  if (isSharedValueLike(prop)) return (prop as SharedValueLike<number>).value;
+  return prop as EdgeFadeViewProps['top'];
+}
+
+export const AnimatedEdgeFadeView = memo(function AnimatedEdgeFadeView(
+  props: AnimatedEdgeFadeViewProps
+): ReactElement {
+  const unwrapped: EdgeFadeViewProps = {
+    ...(props as EdgeFadeViewProps),
+    top: unwrapEdge(props.top),
+    bottom: unwrapEdge(props.bottom),
+    left: unwrapEdge(props.left),
+    right: unwrapEdge(props.right),
+    start: unwrapEdge(props.start),
+    end: unwrapEdge(props.end),
+    radius: unwrap(props.radius),
+  };
+
+  return <EdgeFadeView {...unwrapped} />;
+});

--- a/src/EdgeFadeView.native.tsx
+++ b/src/EdgeFadeView.native.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { StyleSheet } from 'react-native';
 
 import NativeEdgeFadeView from './EdgeFadeViewNativeComponent';
-import { resolveNativeProps } from './normalize';
+import { resolveNativeProps, resolveRadius } from './normalize';
 import type { EdgeFadeViewProps } from './types';
 
 export const EdgeFadeView = memo(function EdgeFadeView(
@@ -31,8 +31,8 @@ export const EdgeFadeView = memo(function EdgeFadeView(
   // (it would trigger a Fabric "unsupported property" warning). We apply it
   // instead via fadeRadius → native clipPath, which is our corner-clip path.
   const flat = (StyleSheet.flatten(style) ?? {}) as Record<string, unknown>;
-  const { borderRadius: styleBorderRadius, ...cleanStyle } = flat;
-  const resolvedRadius = (radius ?? styleBorderRadius) as number | undefined;
+  const { borderRadius: _ignoredBorderRadius, ...cleanStyle } = flat;
+  const resolvedRadius = resolveRadius(radius, style);
 
   return (
     <NativeEdgeFadeView

--- a/src/EdgeFadeView.tsx
+++ b/src/EdgeFadeView.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { View } from 'react-native';
 
 import type { EdgeFadeViewProps } from './types';
-import { resolveNativeProps } from './normalize';
+import { resolveNativeProps, resolveRadius } from './normalize';
 
 // ── Curve sampling ─────────────────────────────────────────────────────────────
 // Returns N alpha values going outer→inner (0 → 1).
@@ -137,9 +137,10 @@ export const EdgeFadeView = memo(function EdgeFadeView(
   delete viewProps.style;
   delete viewProps.children;
 
+  const resolvedRadius = resolveRadius(radius, style);
   const radiusStyle =
-    radius !== undefined
-      ? { borderRadius: radius, overflow: 'hidden' as const }
+    resolvedRadius !== undefined
+      ? { borderRadius: resolvedRadius, overflow: 'hidden' as const }
       : null;
 
   if (n.mode === 'overlay') {

--- a/src/__tests__/normalize.test.ts
+++ b/src/__tests__/normalize.test.ts
@@ -180,3 +180,44 @@ describe('resolveNativeProps — edge independence', () => {
     expect(n.fadeRight).toBe(40);
   });
 });
+
+// ── DEV warnings ───────────────────────────────────────────────────────────────
+
+describe('resolveNativeProps — DEV warnings', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('warns when global color is set with explicit mode="mask"', () => {
+    resolveNativeProps({ bottom: true, color: '#fff', mode: 'mask' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('`color` is ignored when `mode="mask"`')
+    );
+  });
+
+  test('warns when EdgeConfig.color is set with explicit mode="mask"', () => {
+    resolveNativeProps({ bottom: { color: '#fff' }, mode: 'mask' });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  test('does not warn when mode is not set explicitly (auto-infers overlay)', () => {
+    resolveNativeProps({ bottom: true, color: '#fff' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('does not warn when color is absent', () => {
+    resolveNativeProps({ bottom: true, mode: 'mask' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('does not warn for explicit mode="overlay" with color', () => {
+    resolveNativeProps({ bottom: true, color: '#fff', mode: 'overlay' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/normalize.test.ts
+++ b/src/__tests__/normalize.test.ts
@@ -1,4 +1,4 @@
-import { resolveNativeProps } from '../normalize';
+import { resolveNativeProps, resolveRadius } from '../normalize';
 
 // ── Defaults ───────────────────────────────────────────────────────────────────
 
@@ -219,5 +219,42 @@ describe('resolveNativeProps — DEV warnings', () => {
   test('does not warn for explicit mode="overlay" with color', () => {
     resolveNativeProps({ bottom: true, color: '#fff', mode: 'overlay' });
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── Radius resolution ──────────────────────────────────────────────────────────
+
+describe('resolveRadius', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('returns the radius prop when set', () => {
+    expect(resolveRadius(12, undefined)).toBe(12);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('returns undefined when radius is unset and style has no borderRadius', () => {
+    expect(resolveRadius(undefined, undefined)).toBeUndefined();
+    expect(resolveRadius(undefined, { margin: 8 })).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('ignores style.borderRadius and warns when it is set', () => {
+    expect(resolveRadius(undefined, { borderRadius: 16 })).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('`style.borderRadius` is ignored')
+    );
+  });
+
+  test('warns about style.borderRadius even when the radius prop is also set', () => {
+    expect(resolveRadius(8, { borderRadius: 16 })).toBe(8);
+    expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,13 +5,13 @@ export { EdgeFadeView, AnimatedEdgeFadeView };
 
 export type { AnimatedEdgeFadeViewProps } from './AnimatedEdgeFadeView';
 
-/**
- * Raw Fabric native component — escape hatch for power users who want full
- * control over the flat native props (`fadeTop`, `fadeBottom`, etc.) and the
- * Reanimated wrapping themselves. Prefer `AnimatedEdgeFadeView` for animated
- * use cases.
- */
-export { default as NativeEdgeFadeView } from './EdgeFadeViewNativeComponent';
+// NativeEdgeFadeView (raw Fabric component) is intentionally not re-exported
+// from the public barrel. Power users who need it can import it via the
+// dedicated subpath:
+//
+//   import NativeEdgeFadeView from 'react-native-edge-fade/native';
+//
+// For animated use cases prefer `AnimatedEdgeFadeView`.
 
 export type {
   EdgeFadeViewProps,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,15 @@
 import { EdgeFadeView } from './EdgeFadeView';
+import { AnimatedEdgeFadeView } from './AnimatedEdgeFadeView';
 
-export { EdgeFadeView };
+export { EdgeFadeView, AnimatedEdgeFadeView };
+
+export type { AnimatedEdgeFadeViewProps } from './AnimatedEdgeFadeView';
 
 /**
- * Raw Fabric native component — for advanced Reanimated usage.
- *
- * Animate `fadeTop` / `fadeBottom` / `fadeLeft` / `fadeRight` directly as
- * native props so Reanimated's UI-thread shadow-node mutation targets the
- * correct prop instead of Yoga's `top` / `bottom` layout properties.
- *
- * Use `Animated.createAnimatedComponent(NativeEdgeFadeView)` and drive
- * `fadeTop` (not `top`) with `useAnimatedProps`.
- *
- * On web this is a plain View — no visual effects apply.
+ * Raw Fabric native component — escape hatch for power users who want full
+ * control over the flat native props (`fadeTop`, `fadeBottom`, etc.) and the
+ * Reanimated wrapping themselves. Prefer `AnimatedEdgeFadeView` for animated
+ * use cases.
  */
 export { default as NativeEdgeFadeView } from './EdgeFadeViewNativeComponent';
 

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,0 +1,8 @@
+// Power-user escape hatch — the raw Fabric native component.
+//
+// Most consumers should use `EdgeFadeView` (static) or `AnimatedEdgeFadeView`
+// (Reanimated-driven). Import from here only when you need to wire the flat
+// native props (`fadeTop`, `fadeBottom`, `fadeLeft`, `fadeRight`, `fadeRadius`,
+// `curveTop`, …, `mode`, `overlayColor*`) yourself.
+
+export { default as NativeEdgeFadeView } from './EdgeFadeViewNativeComponent';

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,4 +1,10 @@
-import { I18nManager, type ColorValue } from 'react-native';
+import {
+  I18nManager,
+  StyleSheet,
+  type ColorValue,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
 
 import { serializeCurve } from './curves';
 import type {
@@ -57,6 +63,33 @@ export interface NativeEdgeProps {
   overlayColorBottom?: ColorValue;
   overlayColorLeft?: ColorValue;
   overlayColorRight?: ColorValue;
+}
+
+/**
+ * Resolve the effective corner radius.
+ *
+ * `radius` is the only supported source. `style.borderRadius` is intentionally
+ * ignored — using it would not integrate with the fade mask (the gradient
+ * would clip square corners even on a rounded container). When
+ * `style.borderRadius` is detected we log a `__DEV__` warning so the user
+ * knows to migrate to the `radius` prop.
+ */
+export function resolveRadius(
+  radius: number | undefined,
+  style: StyleProp<ViewStyle>
+): number | undefined {
+  if (__DEV__) {
+    const flat = StyleSheet.flatten(style) as
+      | { borderRadius?: number }
+      | undefined;
+    if (flat?.borderRadius != null) {
+      console.warn(
+        '[EdgeFadeView] `style.borderRadius` is ignored — use the `radius` ' +
+          'prop instead so the corner clip integrates with the fade mask.'
+      );
+    }
+  }
+  return radius;
 }
 
 export function resolveNativeProps(props: EdgeFadeViewProps): NativeEdgeProps {

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -83,6 +83,13 @@ export function resolveNativeProps(props: EdgeFadeViewProps): NativeEdgeProps {
 
   const mode: EdgeFadeMode = props.mode ?? (hasColor ? 'overlay' : 'mask');
 
+  if (__DEV__ && hasColor && props.mode === 'mask') {
+    console.warn(
+      '[EdgeFadeView] `color` is ignored when `mode="mask"` is set explicitly. ' +
+        'Either remove `color` or switch to `mode="overlay"`.'
+    );
+  }
+
   return {
     fadeTop: top?.size ?? 0,
     fadeBottom: bottom?.size ?? 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,14 @@ export interface EdgeFadeViewProps extends ViewProps {
   mode?: EdgeFadeMode;
   /** Global overlay color (overlay mode). Per-edge `EdgeConfig.color` overrides this. */
   color?: ColorValue;
-  /** Apply rounded clip via native layer. */
+  /**
+   * Corner radius (dp) applied as a native clip path that also clips the fade
+   * mask, keeping the gradient flush with the rounded edge.
+   *
+   * Use this instead of `style.borderRadius`. `style.borderRadius` is ignored
+   * (a `__DEV__` warning is logged) because it would only round the wrapper
+   * view without clipping the fade gradient.
+   */
   radius?: number;
   style?: StyleProp<ViewStyle>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10696,6 +10696,10 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
+    react-native-reanimated: ">=3.0.0"
+  peerDependenciesMeta:
+    react-native-reanimated:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Tightens the public API surface around three frictions called out in the audit, plus one DX warning. The library now exposes a coherent two-component contract (`EdgeFadeView` for static, `AnimatedEdgeFadeView` for animated) with a single way to do each thing.

---

## What changed

### 1. Single source for corner radius

**Before:** `radius` prop **and** `style.borderRadius` both worked, with the former silently winning. Two ways to do the same thing.

**After:** `radius` is the only supported source. `style.borderRadius` triggers a `__DEV__` warning pointing the user at `radius`, and is otherwise ignored on the fade pipeline.

The reason `style.borderRadius` cannot be the source is structural: it would only round the wrapper view without clipping the fade gradient, leaving the gradient flush with a square corner on the rounded container. `radius` flows through `fadeRadius` to a native `clipPath` that clips both the content and the fade mask in lock-step.

### 2. `AnimatedEdgeFadeView` for Reanimated-driven fades

**Before:** animating the fade depth required wrapping the raw Fabric component manually:

```tsx
const ReanimatedNativeEdgeFadeView =
  Animated.createAnimatedComponent(NativeEdgeFadeView);

const animatedProps = useAnimatedProps(() => ({
  fadeTop: scrollY.value,
}));

<ReanimatedNativeEdgeFadeView
  animatedProps={animatedProps}
  fadeBottom={600}
  ...
/>
```

Two prop lexicons (`top` vs `fadeTop`), `animatedProps`, a separately constructed component — visibly an escape hatch.

**After:** ergonomic, single-component API:

```tsx
const topFade = useDerivedValue(() =>
  interpolate(scrollY.value, [0, 120], [0, 120])
);

<AnimatedEdgeFadeView top={topFade} bottom={600} mode="mask" />
```

Internally `AnimatedEdgeFadeView` wraps `NativeEdgeFadeView` with `Animated.createAnimatedComponent`, detects `SharedValue` inputs on the animatable surface (`top`, `bottom`, `left`, `right`, `start`, `end`, `radius`), and routes them through a `useAnimatedProps` worklet so updates stay on the UI thread. Non-animated props (`mode`, `curve`, `color`, `size`, `EdgeConfig`) work as usual.

`react-native-reanimated` becomes an **optional peer dependency** (`peerDependenciesMeta.optional: true`). The static `EdgeFadeView` remains zero-peer. `AnimatedEdgeFadeView` lazy-requires Reanimated at module load; if it's missing, the component throws a clear error on first render rather than failing the import.

### 3. Hide `NativeEdgeFadeView` from the main barrel

**Before:** `NativeEdgeFadeView` was exported from the package root, inviting the manual `Animated.createAnimatedComponent` pattern.

**After:** the main entry exposes only `EdgeFadeView` and `AnimatedEdgeFadeView`. The raw Fabric component is still available via a dedicated subpath for advanced cases:

```tsx
import { NativeEdgeFadeView } from 'react-native-edge-fade/native';
```

Most consumers never touch it.

### 4. `__DEV__` warning when `color` is set with explicit `mode="mask"`

`color` (or `EdgeConfig.color`) was silently ignored when the user set `mode="mask"` explicitly, making the prop look broken from the consumer side. We now emit a `__DEV__`-only `console.warn` pointing at the mismatch.

---

## Public surface after this PR

```ts
import {
  EdgeFadeView,
  AnimatedEdgeFadeView,
  // types
  EdgeFadeViewProps,
  AnimatedEdgeFadeViewProps,
  EdgeFadeCurve,
  EdgeFadeMode,
  EdgeConfig,
  CurvePreset,
  CubicBezierCurve,
  StopsCurve,
} from 'react-native-edge-fade';

// power-user escape hatch
import { NativeEdgeFadeView } from 'react-native-edge-fade/native';
```

---

## Breaking changes

- `import { NativeEdgeFadeView } from 'react-native-edge-fade'` no longer resolves. Use either `AnimatedEdgeFadeView` (recommended) or `import { NativeEdgeFadeView } from 'react-native-edge-fade/native'`.
- `style.borderRadius` is no longer respected as a fade-clip source. Migrate to the `radius` prop (the warning fires in `__DEV__`).

The library is pre-1.0 (`0.1.0`), so semver-wise both changes are allowed in a minor bump, but the migration paths are mechanical.

---

## Migration

```diff
- import { NativeEdgeFadeView } from 'react-native-edge-fade';
- import Animated, { useAnimatedProps } from 'react-native-reanimated';
- const Anim = Animated.createAnimatedComponent(NativeEdgeFadeView);
- const animatedProps = useAnimatedProps(() => ({ fadeTop: sv.value }));
- <Anim animatedProps={animatedProps} fadeBottom={80} mode="mask">
+ import { AnimatedEdgeFadeView } from 'react-native-edge-fade';
+ <AnimatedEdgeFadeView top={sv} bottom={80} mode="mask">
    {/* children */}
- </Anim>
+ </AnimatedEdgeFadeView>
```

```diff
- <EdgeFadeView bottom={80} style={{ borderRadius: 16, ... }} />
+ <EdgeFadeView bottom={80} radius={16} style={{ ... }} />
```

---

## Files touched

- `src/index.tsx` — barrel cleanup, drop `NativeEdgeFadeView` re-export
- `src/native.ts` — new subpath entry for `NativeEdgeFadeView`
- `src/AnimatedEdgeFadeView.native.tsx` — Reanimated wrapper
- `src/AnimatedEdgeFadeView.tsx` — web fallback (unwraps `.value` at render)
- `src/normalize.ts` — `resolveRadius()` helper + DEV warning for `color` + `mode="mask"`
- `src/types.ts` — JSDoc on `radius`
- `src/EdgeFadeView.native.tsx` / `src/EdgeFadeView.tsx` — use `resolveRadius()`, drop the silent `style.borderRadius` precedence
- `src/__tests__/normalize.test.ts` — 10 new tests (5 for `resolveRadius`, 5 for the color/mask warning)
- `package.json` — `peerDependenciesMeta.optional` for Reanimated; `./native` subpath export
- `README.md` — replace the Reanimated `NativeEdgeFadeView` section with `AnimatedEdgeFadeView`, document the subpath, update the radius row
- `example/src/App.tsx` — migrate the masonry grid demo to `AnimatedEdgeFadeView`

---

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — **57 passing** (10 new across `resolveRadius` and the color/mask DEV warning)
- [x] `npx eslint src/` clean
- [x] `./gradlew :react-native-edge-fade:compileDebugKotlin` clean
- [x] Manual scroll test on Android device — animated top fade still drives off `scrollY`, bottom static fade unchanged
- [ ] Smoke test the example app on a clean install (no `node_modules/.cache`, no Metro cache) to confirm the optional peer lookup works in a real Expo dev client
- [ ] Confirm DEV warnings fire on a sample app:
  - `<EdgeFadeView bottom={80} color="#fff" mode="mask" />`
  - `<EdgeFadeView bottom={80} style={{ borderRadius: 16 }} />`
- [ ] Verify subpath import (`react-native-edge-fade/native`) resolves correctly under both Metro and TypeScript

---

## Follow-ups (not in this PR)

- Compose `Modifier.fadingEdge` interop — opens a Kotlin-native market for the same shaders. Tracked in `todo.md`.
- `RenderEffect.createRuntimeShaderEffect` fast path on Android API 31+. Tracked in `todo.md`.
- iOS micro-optimizations (`NSNumber*` cache, drop `_overlayContainer`, `traitCollection.displayScale`, `cornerCurve = .continuous`). Tracked in `todo.md`.